### PR TITLE
Compile with a slightly newer ZXing as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ add_definitions(
 )
 
 # Enable C++11 features for clang and gcc.
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 
 # ################# CMake module includes ##########################################################

--- a/src/BarcodeScanner.cpp
+++ b/src/BarcodeScanner.cpp
@@ -53,7 +53,7 @@ static Barcode::DecodeResult toDecodeResult(const ZXing::Result& result) {
     return { static_cast<Barcode::DecodeStatus>(result.status()),
         static_cast<Barcode::Format>(result.format()),
         QString::fromStdWString(result.text()),
-        QByteArray(result.rawBytes().charPtr(), result.rawBytes().length()),
+        QByteArray(reinterpret_cast<const char*>(result.rawBytes().data()), result.rawBytes().size()),
         toQVectorOfQPoints(result.resultPoints()),
         result.isValid() };
 }


### PR DESCRIPTION
This should not break compatibility with older versions. The C++14 bump is
needed as ZXing now has lambdas with auto parameters in its headers.